### PR TITLE
removed /data ending from docker-compose.yml file to avoid the (700) …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       POSTGRES_USER: vice
       POSTGRES_PASSWORD: vice
     volumes:
-      - ./.docker/postgres/data/:/var/lib/postgresql/data
+      - ./.docker/postgres/data/:/var/lib/postgresql
       - ./.docker/postgres/initdb.d/:/docker-entrypoint-initdb.d/
     ports:
     - 5432:5432


### PR DESCRIPTION
Removed '/data' from volume in docker-compose.yml which was causing a (700) error and failing to set-up the postgres server.